### PR TITLE
Add x86 build support for Detours

### DIFF
--- a/external/Detours/CMakeLists.txt
+++ b/external/Detours/CMakeLists.txt
@@ -33,7 +33,7 @@ ExternalProject_Add(detours_ep
         CONFIGURE_COMMAND   ""            # no configure step
         BUILD_BYPRODUCTS    ${DETOURS_OUT_LIB}
         BUILD_IN_SOURCE     1
-        BUILD_COMMAND       ${CMAKE_COMMAND} -E chdir ${DETOURS_BUILDWD} nmake
+        BUILD_COMMAND       ${CMAKE_COMMAND} -E chdir ${DETOURS_BUILDWD} nmake DETOURS_TARGET_PROCESSOR=${DETOURS_ARCH}
         INSTALL_COMMAND     ""
         LOG_BUILD           1
 )


### PR DESCRIPTION
Could be off the mark, but when trying to add ByteWeaver to an x86 project it was failing due to Detours building for x64 then searching in the x86 dir for the x86 lib.  Manually building it for my project passing the architecture in through DETOURS_TARGET_PROCESSOR fixed it 😊